### PR TITLE
Add Craft 5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "codemonauts/craft-basicauth",
   "description": "Craft CMS plugin for HTTP Basic Authentication within templates.",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "type": "craft-plugin",
   "keywords": [
     "craft",
@@ -22,8 +22,9 @@
     "issues": "https://github.com/codemonauts/craft-basicauth/issues"
   },
   "require": {
-    "craftcms/cms": "^4.0.0-alpha.1",
-    "symfony/http-foundation": "^v6.4.35",
+    "php": "^8.2",
+    "craftcms/cms": "^5.0.0",
+    "symfony/http-foundation": "^6.4 || ^7.0",
     "ext-json": "*"
   },
   "autoload": {

--- a/src/services/AuthService.php
+++ b/src/services/AuthService.php
@@ -5,6 +5,7 @@ namespace codemonauts\basicauth\services;
 use codemonauts\basicauth\BasicAuth;
 use Craft;
 use craft\base\Component;
+use craft\helpers\App;
 use craft\helpers\StringHelper;
 use Symfony\Component\HttpFoundation\IpUtils;
 
@@ -28,7 +29,7 @@ class AuthService extends Component
         $matchedSite = true;
 
         if ($env !== null) {
-            if ($env != Craft::$app->config->env) {
+            if ($env != App::env('CRAFT_ENVIRONMENT')) {
                 $matchedEnv = false;
             }
         }


### PR DESCRIPTION
Update CMS version constraint, PHP 8.2 requirement, replace removed Craft::$app->config->env with App::env('CRAFT_ENVIRONMENT')